### PR TITLE
Fix empty prefix from property namespace.

### DIFF
--- a/io/plugins/it.geosolutions.hale.io.appschema.test/src/it/geosolutions/hale/io/appschema/writer/AppSchemaMappingGeneratorTest.java
+++ b/io/plugins/it.geosolutions.hale.io.appschema.test/src/it/geosolutions/hale/io/appschema/writer/AppSchemaMappingGeneratorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package it.geosolutions.hale.io.appschema.writer;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+
+import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultPropertyDefinition;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition;
+import eu.esdihumboldt.hale.common.schema.model.impl.internal.ReparentProperty;
+
+/**
+ * Testing class for {@link AppSchemaMappingGenerator} class.
+ * 
+ * @author Fernando Mino, Geosolutions.
+ */
+public class AppSchemaMappingGeneratorTest {
+
+	private static final String TYPE_NAMESPACE = "http://geoserver.org/1.0";
+
+	/**
+	 * Check tryInferNamespacePrefix method for infer Prefix on some cases child
+	 * QName doesn't have any value.
+	 */
+	@Test
+	public void testTryInferNamespacePrefix() {
+		DefaultTypeDefinition parentType = new DefaultTypeDefinition(
+				new QName(TYPE_NAMESPACE, "ParentType", "geo"));
+
+		DefaultTypeDefinition definitionGroup = new DefaultTypeDefinition(
+				new QName(TYPE_NAMESPACE, "GroupDef", "geo"));
+
+		DefaultTypeDefinition propertyType = new DefaultTypeDefinition(
+				new QName(TYPE_NAMESPACE, "PropertyType", ""));
+		final DefaultPropertyDefinition propertyDefinition = new DefaultPropertyDefinition(
+				new QName(TYPE_NAMESPACE, "level"), definitionGroup, propertyType);
+		PropertyDefinition child = new ReparentProperty(propertyDefinition, parentType);
+		QName qName = AppSchemaMappingGenerator.tryInferNamespacePrefix(child);
+		assertEquals(TYPE_NAMESPACE, qName.getNamespaceURI());
+		assertEquals("geo", qName.getPrefix());
+	}
+
+}


### PR DESCRIPTION
createNamespacesForPath method is unable to get the proper prefix for the required namespace and passing an empty string.

So having an empty string as prefix, other part of the code replace such empty prefix with an auto generated prefix.

See:
https://github.com/geosolutions-it/hale-appschema-plugin/blob/2f9ea047142af8f9a11e153f7b4c3fe8ce6807a8/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/writer/AppSchemaMappingGenerator.java#L542

This PR fix this bug by getting former prefix from parent group if available.