### PR TITLE
Default prefix on non root namespaces issue

### DIFF
--- a/io/plugins/it.geosolutions.hale.io.appschema.test/src/it/geosolutions/hale/io/appschema/writer/internal/AbstractPropertyTransformationHandlerTest.java
+++ b/io/plugins/it.geosolutions.hale.io.appschema.test/src/it/geosolutions/hale/io/appschema/writer/internal/AbstractPropertyTransformationHandlerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package it.geosolutions.hale.io.appschema.writer.internal;
+
+import static org.junit.Assert.assertFalse;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+import eu.esdihumboldt.hale.io.xsd.reader.internal.AnonymousXmlType;
+
+/**
+ * Unit tests for {@link AbstractPropertyTransformationHandler} class.
+ */
+public class AbstractPropertyTransformationHandlerTest {
+
+	@Test
+	public void testIsValidFeatureType() {
+		TypeDefinition type = new AnonymousXmlType(new QName("test", "test"));
+		assertFalse(AbstractPropertyTransformationHandler.isValidFeatureType(type));
+	}
+
+}

--- a/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/model/ChainConfiguration.java
+++ b/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/model/ChainConfiguration.java
@@ -190,4 +190,12 @@ public class ChainConfiguration {
 		this.referenceLinkedType = referenceLinkedType;
 	}
 
+	@Override
+	public String toString() {
+		return "ChainConfiguration [chainIndex=" + chainIndex + ", prevChainIndex=" + prevChainIndex
+				+ ", jaxbNestedTypeTarget=" + jaxbNestedTypeTarget + ", nestedTypeTarget="
+				+ nestedTypeTarget + ", mappingName=" + mappingName + ", referenceLinkedType="
+				+ referenceLinkedType + "]";
+	}
+
 }

--- a/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/writer/AbstractAppSchemaConfigurator.java
+++ b/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/writer/AbstractAppSchemaConfigurator.java
@@ -110,11 +110,9 @@ public abstract class AbstractAppSchemaConfigurator extends AbstractAlignmentWri
 		WorkspaceConfiguration workspaceConfParam = getWorkspaceConfigurationParameter();
 
 		// get the db uri
-		final String dataStoreURI = dataStoreParam.getParameters().getParameter().stream()
-				.filter(p -> "data_store".equals(p.getName())).findFirst().map(Parameter::getValue)
-				.orElse("");
+		String dataStoreURI = fetchDataStoreUri(dataStoreParam);
 		// decide MappingGeneratot implementation
-		if (dataStoreURI.startsWith("mongodb")) {
+		if (dataStoreURI != null && dataStoreURI.startsWith("mongodb")) {
 			generator = new MongoMappingGenerator(getAlignment(), getTargetSchema(), dataStoreParam,
 					featureChainingParam, workspaceConfParam);
 		}
@@ -123,6 +121,16 @@ public abstract class AbstractAppSchemaConfigurator extends AbstractAlignmentWri
 					dataStoreParam, featureChainingParam, workspaceConfParam);
 		}
 		generator.generateMapping(reporter);
+	}
+
+	private String fetchDataStoreUri(DataStore dataStoreParam) {
+		if (dataStoreParam.getParameters() == null
+				|| dataStoreParam.getParameters().getParameter() == null)
+			return "";
+
+		return dataStoreParam.getParameters().getParameter().stream().filter(p -> p != null)
+				.filter(p -> "data_store".equals(p.getName())).findFirst().map(Parameter::getValue)
+				.orElse("");
 	}
 
 	@Override

--- a/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/writer/AppSchemaMappingGenerator.java
+++ b/io/plugins/it.geosolutions.hale.io.appschema/src/it/geosolutions/hale/io/appschema/writer/AppSchemaMappingGenerator.java
@@ -60,6 +60,7 @@ import eu.esdihumboldt.hale.common.schema.model.SchemaSpace;
 import eu.esdihumboldt.hale.common.schema.model.impl.AbstractPropertyDecorator;
 import eu.esdihumboldt.hale.common.schema.model.impl.DefaultPropertyDefinition;
 import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition;
+import eu.esdihumboldt.hale.io.xsd.reader.internal.XmlTypeDefinition;
 import it.geosolutions.hale.io.appschema.AppSchemaIO;
 import it.geosolutions.hale.io.appschema.impl.internal.generated.app_schema.AppSchemaDataAccessType;
 import it.geosolutions.hale.io.appschema.impl.internal.generated.app_schema.NamespacesPropertyType.Namespace;
@@ -526,8 +527,34 @@ public class AppSchemaMappingGenerator implements MappingGenerator {
 						prefix = defaultType.getName().getPrefix();
 				}
 			}
+			else {
+				String newPrefix = getPrefix(dpd);
+				if (StringUtils.isNotBlank(newPrefix)) {
+					prefix = newPrefix;
+				}
+			}
 		}
 		return new QName(namespaceURI, "", prefix);
+	}
+
+	private static String getPrefix(PropertyDefinition dpd) {
+		try {
+			if (dpd instanceof AbstractPropertyDecorator) {
+				AbstractPropertyDecorator cdp = (AbstractPropertyDecorator) dpd;
+				PropertyDefinition property = cdp.getDecoratedProperty();
+				if (property instanceof AbstractPropertyDecorator) {
+					DefinitionGroup declaringGroup = ((AbstractPropertyDecorator) property)
+							.getDeclaringGroup();
+					if (declaringGroup instanceof XmlTypeDefinition) {
+						XmlTypeDefinition typeDef = (XmlTypeDefinition) declaringGroup;
+						return typeDef.getName().getPrefix();
+					}
+				}
+			}
+		} catch (NullPointerException ex) {
+			log.warn("Prefix not found", ex);
+		}
+		return null;
 	}
 
 	private boolean isIsolated(String namespaceUri) {


### PR DESCRIPTION
This PR fixes an issue making all non root featureType namespaces are written as default names like "ns__1".